### PR TITLE
Redesign gennerate question helpers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,7 @@ import { CssBaseline, Box } from '@material-ui/core'
 // THEME
 import theme from "./theme"
 import { ThemeProvider, } from '@material-ui/core/styles'
+import { chooseRandomFromArray } from './logic/lowLevelHelpers';
 
 
 export default function App() {
@@ -76,6 +77,14 @@ export default function App() {
     }
 
     function handleAnswerSubmit(answerIsCorrect) {
+    const waysToSayCorrect = [
+        "Correct!",
+        "Right!",
+        "That's it!",
+        "Good job!",
+        "Very good!"
+    ]
+        const answerFeedbackHeaderText = (answerIsCorrect ? chooseRandomFromArray(waysToSayCorrect) : `Nope. It was ${question.correctAnswer}.`)
         let moveToAdd = (answerIsCorrect) ? activeCell : -1
         let updatedMoveList = moveList.concat(moveToAdd)
         let updatedGameStatus = getGameStatus(updatedMoveList)

--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,7 @@ export default function App() {
 
     const [question, setQuestion] = React.useState(testQuestion())
     
+
     // LAYOUT
     const height = useScreenHeight()
     const width = useScreenWidth()
@@ -64,6 +65,9 @@ export default function App() {
         openMathQuestionModal(lowestUnclaimedCell)
     }
     function openMathQuestionModal(activeCell) {
+        const score = nextPlayersMoves(gameStatus, moveList).length
+
+        setQuestion(generateQuestion(mathTopics, score))
         // GET question here?
         setOpenModal("question")
         setActiveCell(activeCell)
@@ -158,12 +162,13 @@ export default function App() {
                         />
                         <MathQuestionModal
                             // turnNumber={moveList.length}
-                            turnNumber={turnNumber}
+                            // turnNumber={turnNumber}
                             open={(openModal === "question")}
-                            // question={question}
-                            mathTopics={mathTopics}
-                            questionsRightSoFar={questionsRightSoFar}
+                            question={question}
                             handleAnswerSubmit={handleAnswerSubmit}
+                            // mathTopics={mathTopics}
+                            // questionsRightSoFar={questionsRightSoFar}
+                            // handleAnswerSubmit={handleAnswerSubmit}
                             boardSideLength={boardSideLength}
                         />
                         <GameBoard

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import { MathQuestionModal } from "./modals/MathQuestionModal";
 // import { GameSettingsModal } from "./components/GameSettingsModal";
 
 // Game Logic
-import { gameIsOver, getColumnData, getGameStatus, playerOnesNumbers, playerTwosNumbers } from './logic/connectFourLogic'
+import { gameIsOver, getColumnData, getGameStatus, playerOnesMoves, playerTwosMoves, nextPlayersMoves } from './logic/connectFourLogic'
 import { testQuestion, generateQuestion } from './logic/questionGenerator'
 // import { chooseRandomFromArray } from "./logic/lowLevelHelpers";
 
@@ -121,23 +121,7 @@ export default function App() {
         setOpenModal("none")
     }
 
-    function getNextPlayersMoves() {
-        if (gameStatus === "playerOnesTurn") {
-            return playerOnesNumbers(moveList)
-        }
-        else if (gameStatus === "playerTwosTurn") {
-            return playerTwosNumbers(moveList)
-        }
-        else {
-            console.warn(`getNextPlayersMoves was called but the game is already over`);
-            return []
-        }
-    }
-    let turnNumber = moveList.length
-    let nextPlayersMoves = getNextPlayersMoves()
-    // console.log(`nextPlayersMoves ${nextPlayersMoves}`);
-    let questionsRightSoFar = Math.max(1, nextPlayersMoves.length)
-
+    
     return (
         <React.Fragment>
             <CssBaseline />

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,13 @@ import { MathQuestionModal } from "./modals/MathQuestionModal";
 // import { GameSettingsModal } from "./components/GameSettingsModal";
 
 // Game Logic
-import { gameIsOver, getColumnData, getGameStatus, playerOnesMoves, playerTwosMoves, nextPlayersMoves } from './logic/connectFourLogic'
+import { gameIsOver, 
+    getColumnData, 
+    getGameStatus, 
+    playerOnesMoves, 
+    playerTwosMoves, 
+    nextPlayersMoves, 
+    nextPlayerColor } from './logic/connectFourLogic'
 import { testQuestion, generateQuestion } from './logic/questionGenerator'
 // import { chooseRandomFromArray } from "./logic/lowLevelHelpers";
 
@@ -190,6 +196,9 @@ export default function App() {
                         <MathQuestionModal
                             // turnNumber={moveList.length}
                             // turnNumber={turnNumber}
+                            nextPlayerColor={nextPlayerColor(gameStatus)}
+                            // nextPlayerColor={nextPlayerColor}
+                            gameStatus={gameStatus}
                             open={(openModal === "question")}
                             question={question}
                             headerText={headerText}

--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,9 @@ export default function App() {
     const [question, setQuestion] = React.useState(testQuestion())
     // const [question, setQuestion] = React.useState(generateQuestion(["combining"], 0))
     // const [questsion, setQuestion] = React.useState(generateQuestion(mathTopics, score))
+
+    const [headerText, setHeaderText] = React.useState("")
+
     
 
     // LAYOUT
@@ -67,6 +70,7 @@ export default function App() {
         let lowestUnclaimedCell = lowestUnclaimedRow * 7 + columnIndex
         openMathQuestionModal(lowestUnclaimedCell)
     }
+
     function openMathQuestionModal(activeCell) {
         const score = nextPlayersMoves(gameStatus, moveList).length
 
@@ -76,7 +80,6 @@ export default function App() {
         setActiveCell(activeCell)
     }
 
-    function handleAnswerSubmit(answerIsCorrect) {
     const waysToSayCorrect = [
         "Correct!",
         "Right!",
@@ -84,7 +87,13 @@ export default function App() {
         "Good job!",
         "Very good!"
     ]
+    
+    function handleAnswerSubmit(playersAnswer) {
+        const answerIsCorrect = (Number(playersAnswer.trim()) === question.correctAnswer)
         const answerFeedbackHeaderText = (answerIsCorrect ? chooseRandomFromArray(waysToSayCorrect) : `Nope. It was ${question.correctAnswer}.`)
+        setHeaderText(answerFeedbackHeaderText)
+         
+
         let moveToAdd = (answerIsCorrect) ? activeCell : -1
         let updatedMoveList = moveList.concat(moveToAdd)
         let updatedGameStatus = getGameStatus(updatedMoveList)
@@ -176,6 +185,7 @@ export default function App() {
                             // turnNumber={turnNumber}
                             open={(openModal === "question")}
                             question={question}
+                            headerText={headerText}
                             handleAnswerSubmit={handleAnswerSubmit}
                             // mathTopics={mathTopics}
                             // questionsRightSoFar={questionsRightSoFar}

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import { MathQuestionModal } from "./modals/MathQuestionModal";
 
 // Game Logic
 import { gameIsOver, getColumnData, getGameStatus, playerOnesNumbers, playerTwosNumbers } from './logic/connectFourLogic'
-// import { blankQuestion, generateQuestion } from './logic/questionGenerator'
+import { testQuestion, generateQuestion } from './logic/questionGenerator'
 // import { chooseRandomFromArray } from "./logic/lowLevelHelpers";
 
 // Custom Hooks
@@ -38,6 +38,7 @@ export default function App() {
     const [openModal, setOpenModal] = React.useState("none") // Enum: "none", "question", "abandonGame", "newGameSettings", 
     const [activeCell, setActiveCell] = React.useState(null) 
 
+    const [question, setQuestion] = React.useState(testQuestion())
     
     // LAYOUT
     const height = useScreenHeight()

--- a/src/App.js
+++ b/src/App.js
@@ -55,13 +55,17 @@ export default function App() {
         }
         let columnData = getColumnData(columnIndex, moveList)
         let lowestUnclaimedRow = columnData.indexOf("unclaimed")
-        let lowestUnclaimedCell = lowestUnclaimedRow * 7 + columnIndex
         if (lowestUnclaimedRow === -1) {
             console.log(`handleColumnClick() had NO EFFECT since column is full!`)
             return
         }
+        let lowestUnclaimedCell = lowestUnclaimedRow * 7 + columnIndex
+        openMathQuestionModal(lowestUnclaimedCell)
+    }
+    function openMathQuestionModal(activeCell) {
+        // GET question here?
         setOpenModal("question")
-        setActiveCell(lowestUnclaimedCell)
+        setActiveCell(activeCell)
     }
 
     function handleAnswerSubmit(answerIsCorrect) {

--- a/src/App.js
+++ b/src/App.js
@@ -39,6 +39,8 @@ export default function App() {
     const [activeCell, setActiveCell] = React.useState(null) 
 
     const [question, setQuestion] = React.useState(testQuestion())
+    // const [question, setQuestion] = React.useState(generateQuestion(["combining"], 0))
+    // const [questsion, setQuestion] = React.useState(generateQuestion(mathTopics, score))
     
 
     // LAYOUT

--- a/src/App.js
+++ b/src/App.js
@@ -60,13 +60,8 @@ export default function App() {
             console.log(`handleColumnClick() had NO EFFECT since column is full!`)
             return
         }
-        
-        // let newQuestion = generateQuestion(mathTopics, questionsRightSoFar())
-        // console.log(`NEW QUESTION: ${JSON.stringify(newQuestion, null, 4)}`)
-        // setQuestion(newQuestion)
         setOpenModal("question")
         setActiveCell(lowestUnclaimedCell)
-
     }
 
     function handleAnswerSubmit(answerIsCorrect) {
@@ -173,7 +168,6 @@ export default function App() {
                             handleUndoClick={handleUndoClick}
                         />
                         <MathQuestionModal
-                            key={1}
                             // turnNumber={moveList.length}
                             turnNumber={turnNumber}
                             open={(openModal === "question")}

--- a/src/App.js
+++ b/src/App.js
@@ -157,14 +157,14 @@ export default function App() {
                     {/* <WelcomePage /> */}
                     {/* <PlayPage /> */}
                     {/* <InfoPage /> */}
-                    <Box id='play-page' sx={{
-                        height:  boardSideLength,
-                        width:  boardSideLength,
-                        display: 'flex',
-                        flexDirection: 'column',
-
-                        alignItems: 'center',
-                        position: 'relative'
+                    <Box id='play-page' 
+                        sx={{
+                            height:  boardSideLength,
+                            width:  boardSideLength,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            position: 'relative'
                     }}>
                         <InGameMenu
                             handleNewGameClick={openAbandonGameModal}

--- a/src/App.js
+++ b/src/App.js
@@ -73,11 +73,18 @@ export default function App() {
 
     function openMathQuestionModal(activeCell) {
         const score = nextPlayersMoves(gameStatus, moveList).length
-
-        setQuestion(generateQuestion(mathTopics, score))
-        // GET question here?
-        setOpenModal("question")
-        setActiveCell(activeCell)
+        
+        // My first Promise     
+        const newQuestion = generateQuestion(mathTopics, score).then(newQuestion => {
+            console.log(`Opening Modal with Question --> ${JSON.stringify(newQuestion, null, 4)}`);
+            setQuestion(newQuestion)
+            setHeaderText(newQuestion.instructions)
+            setOpenModal("question")
+            setActiveCell(activeCell)
+        })
+        console.log(`Opening Modal with Question --> ${JSON.stringify(newQuestion, null, 4)}`);
+        
+        
     }
 
     const waysToSayCorrect = [

--- a/src/logic/connectFourLogic.js
+++ b/src/logic/connectFourLogic.js
@@ -16,10 +16,10 @@ export function intersect(setOne, setTwo) {
     return setOne.filter(item => setTwo.includes(item))
 }
 
-export function playerOnesNumbers(moveList) {
+export function playerOnesMoves(moveList) {
     return moveList.filter((cell, turn) => turn % 2 === 0).filter(cell => cell !== -1)
 }
-export function playerTwosNumbers(moveList) {
+export function playerTwosMoves(moveList) {
     return moveList.filter((cell, turn) => turn % 2 === 1).filter(cell => cell !== -1)
 }
 
@@ -39,9 +39,34 @@ export function getColumnData(columnIndex, moveList) {
     return boardData.filter((claimStatus, cellId) => cellId % 7 === columnIndex)
 }
 
+
+export function nextPlayer(gameStatus) {
+    if (gameIsOver(gameStatus)) {
+        console.error(`Do not call nextPlayer() when the game is over.`);
+    }
+    return (gameStatus === "playerOnesTurn") ? "playerOne" : "playerTwo"
+} 
+export function nextPlayersMoves(gameStatus, moveList) {
+    if (gameIsOver(gameStatus)) {
+        console.error(`Do not call nextPlayersMoves() when the game is over.`);
+    }
+    return (gameStatus === "playerOnesTurn") ? playerOnesMoves(moveList) : playerTwosMoves(moveList)
+}
 export function nextPlayerColor(gameStatus) {
     return gameIsOver(gameStatus) ? "unclaimed" : (gameStatus === "playerOnesTurn") ? "playerOne" : "playerTwo"
 }
+// function getNextPlayersMoves() {
+//     if (gameStatus === "playerOnesTurn") {
+//         return playerOnesMoves(moveList)
+//     }
+//     else if (gameStatus === "playerTwosTurn") {
+//         return playerTwosMoves(moveList)
+//     }
+//     else {
+//         console.warn(`getNextPlayersMoves was called but the game is already over`);
+//         return []
+//     }
+// }
 
 
 function getLastChipDropped(moveList) {
@@ -57,14 +82,14 @@ function getLastChipDropped(moveList) {
 // This function efficiently checks to see if the last move created a win for the player who made it.
 export function getGameStatus(moveList) {
     let lastPlayerToMove = (moveList.length % 2 === 1) ? "playerOne" : "playerTwo"
-    let lastPlayersNumbers = (lastPlayerToMove === "playerOne") ? playerOnesNumbers(moveList) : playerTwosNumbers(moveList)
-    let lastMoveMade = Number(lastPlayersNumbers.slice(-1))
+    let lastPlayersMoves = (lastPlayerToMove === "playerOne") ? playerOnesMoves(moveList) : playerTwosMoves(moveList)
+    let lastMoveMade = Number(lastPlayersMoves.slice(-1))
     let linesAffectedByLastMove = cellToLinesMap.get(lastMoveMade)
     for (let i = 0; i < linesAffectedByLastMove.length; i++) {
         let line = linesAffectedByLastMove[i]
         let cellsInLine = lineToCellsMap.get(line)
         // For added efficiency I could at this point remove the lastMoveMade from cells in line and in the next line look for intersections of length 3.
-        if (intersect(cellsInLine, lastPlayersNumbers).length === 4) {
+        if (intersect(cellsInLine, lastPlayersMoves).length === 4) {
             return (lastPlayerToMove === 'playerOne') ? 'playerOneWins' : 'playerTwoWins'
         }
     }

--- a/src/logic/questionGenerator.js
+++ b/src/logic/questionGenerator.js
@@ -73,13 +73,13 @@ function getCombiningQuestion(difficulty) {
         "missingSumThree",
         "missingAddendTwo",
         "missingAddendThree",
-
+        // "combineAndCompare",   // a + b _ c - d
+        // "missingDifference",  // a - b = _
+        // "missingMinuend",     // a - _ = c
+        // "howFarApart",        // a and b
     ]
     let type = chooseRandomFromArray(types)
-    // "combineAndCompare"   // a + b _ c - d
-    // "missingDifference",  // a - b = _
-    // "missingMinuend",     // a - _ = c
-    // "howFarApart",        // a and b
+   
 
     const missingSumInstructions = [
         "What's the Sum?",
@@ -101,9 +101,10 @@ function getCombiningQuestion(difficulty) {
     else if (type === "missingAddendTwo") {
         question = missingAddendTwo(difficulty)
     }
+    else if (type === "missingSumThree") {
+        question = missingSumThree(difficulty)
+    } 
     else if (type === "missingAddendThree") {
-        question = missingAddendThree(difficulty)
-    } else if (type === "missingAddendThree") {
         question = missingAddendThree(difficulty)
     }
     return question

--- a/src/logic/questionGenerator.js
+++ b/src/logic/questionGenerator.js
@@ -70,8 +70,6 @@ function getCombiningQuestion(difficulty) {
 
     ]
     let type = chooseRandomFromArray(types)
-    // "missingAddendTwo",
-    // "missingSumThree",
     // "missingAddendThree",
     // "combineAndCompare"   // a + b _ c - d
     // "missingDifference",  // a - b = _

--- a/src/logic/questionGenerator.js
+++ b/src/logic/questionGenerator.js
@@ -64,6 +64,10 @@ export function generateQuestion(mathTopics, score) {
 function getCombiningQuestion(difficulty) {
     let types = [
         "missingSumTwo",
+        "missingAddendTwo",
+        "missingAddendTwo",
+        "missingSumThree",
+
     ]
     let type = chooseRandomFromArray(types)
     // "missingAddendTwo",
@@ -94,6 +98,11 @@ function getCombiningQuestion(difficulty) {
     else if (type === "missingAddendTwo") {
         question = missingAddendTwo(difficulty)
     }
+    else if (type === "missingAddendThree") {
+        question = missingAddendThree(difficulty)
+    } else if (type === "missingAddendThree") {
+        question = missingAddendThree(difficulty)
+    }
     return question
     
     function getSumOfTwoFact(difficulty) {
@@ -103,6 +112,13 @@ function getCombiningQuestion(difficulty) {
         // console.log(`Combining Vars of difficulty "${difficultyLevel}": ${[a, b, c]}`);
         return [a, b, c]
     }
+    function getSumOfThreeFact(difficulty) {
+        let a = (difficulty === "hard") ? getHardAddend() : getMediumAddend()
+        let b = (difficulty === "easy") ? getEasyAddend() : getMediumAddend()
+        let c = (difficulty === "hard") ? getEasyAddend() : getMediumAddend()
+        let d = a + b + c
+        return [a, b, c, d]
+    }
     
     function missingSumTwo(difficulty) {
         let vars = getSumOfTwoFact(difficulty)
@@ -110,8 +126,19 @@ function getCombiningQuestion(difficulty) {
             type: "missingSumTwo",
             vars: vars,
             correctAnswer: vars[2],
-            instructions: chooseRandomFromArray(missingSumInstructions),
             equationString: `${vars[0]} + ${vars[1]} = __`,
+            instructions: chooseRandomFromArray(missingSumInstructions),
+            inputType: "textField",
+        }
+    }
+    function missingSumThree(difficulty) {
+        let vars = getSumOfThreeFact(difficulty)
+        return question = {
+            type: "missingSumThree",
+            vars: vars,
+            correctAnswer: vars[3],
+            equationString: `${vars[0]} + ${vars[1]} + ${vars[2]} = __`,
+            instructions: chooseRandomFromArray(missingSumInstructions),
             inputType: "textField",
         }
     }
@@ -122,8 +149,19 @@ function getCombiningQuestion(difficulty) {
             type: "missingAddendTwo",
             vars: vars,
             correctAnswer: vars[1],
+            equationString: `${vars[0]} + __ = + ${vars[2]}`,
             instructions: chooseRandomFromArray(missingAddendInstructions),
-            equationString: `${vars[0]} + __ = ${vars[2]}`,
+            inputType: "textField",
+        }
+    }
+    function missingAddendThree(difficulty) {
+        let vars = getSumOfThreeFact(difficulty)
+        return question = {
+            type: "missingAddendThree",
+            vars: vars,
+            correctAnswer: vars[1],
+            equationString: `${vars[0]} + __ + ${vars[2]} = + ${vars[3]}`,
+            instructions: chooseRandomFromArray(missingAddendInstructions),
             inputType: "textField",
         }
     }

--- a/src/logic/questionGenerator.js
+++ b/src/logic/questionGenerator.js
@@ -1,13 +1,13 @@
 import { randomInt, chooseRandomFromArray } from "./lowLevelHelpers";
 
-export function blankQuestion() {
-    let vars = [0, 0, 0, 0]
+export function testQuestion() {
+    let vars = [1, 2, 3, 6]
     return {
         type: "missingSumThree",
         vars: vars,
         correctAnswer: vars[3],
         equationString: `${vars[0]} + ${vars[1]} + ${vars[2]} = __`,
-        instructions: "",
+        instructions: "Test Question",
         inputType: "textField",
     }
 }

--- a/src/logic/questionGenerator.js
+++ b/src/logic/questionGenerator.js
@@ -29,8 +29,10 @@ function determineDifficulty(score) {
 }
 
 
-
 export function generateQuestion(mathTopics, score) {
+    // 1) pick topic from array of options
+    // 2) determine difficulty based on score
+    // 3) call topic specific question generator
     return new Promise((resolve, reject) => {
         const topic = chooseRandomFromArray(mathTopics)
         const difficulty = determineDifficulty(score)
@@ -59,13 +61,7 @@ export function generateQuestion(mathTopics, score) {
         resolve(question)
     });
     
-    // 1) pick topic from array of options
-    // 2) determine difficulty based on score
-    // 3) call topic specific question generator
-    
 }
-
-
 
 function getCombiningQuestion(difficulty) {
     let types = [
@@ -80,7 +76,6 @@ function getCombiningQuestion(difficulty) {
     ]
     let type = chooseRandomFromArray(types)
    
-
     const missingSumInstructions = [
         "What's the Sum?",
         "Find the Total"
@@ -153,7 +148,7 @@ function getCombiningQuestion(difficulty) {
             type: "missingAddendTwo",
             vars: vars,
             correctAnswer: vars[1],
-            equationString: `${vars[0]} + __ = + ${vars[2]}`,
+            equationString: `${vars[0]} + __ = ${vars[2]}`,
             instructions: chooseRandomFromArray(missingAddendInstructions),
             inputType: "textField",
         }
@@ -164,7 +159,7 @@ function getCombiningQuestion(difficulty) {
             type: "missingAddendThree",
             vars: vars,
             correctAnswer: vars[1],
-            equationString: `${vars[0]} + __ + ${vars[2]} = + ${vars[3]}`,
+            equationString: `${vars[0]} + __ + ${vars[2]} = ${vars[3]}`,
             instructions: chooseRandomFromArray(missingAddendInstructions),
             inputType: "textField",
         }

--- a/src/logic/questionGenerator.js
+++ b/src/logic/questionGenerator.js
@@ -1,12 +1,13 @@
 import { randomInt, chooseRandomFromArray } from "./lowLevelHelpers";
 
 export function blankQuestion() {
+    let vars = [0, 0, 0, 0]
     return {
         type: "missingSumThree",
-        vars: [0,0,0,0],
-        correctAnswer: 0,
+        vars: vars,
+        correctAnswer: vars[3],
+        equationString: `${vars[0]} + ${vars[1]} + ${vars[2]} = __`,
         instructions: "",
-        equationString: `0 + 0 + 0 = __`,
         inputType: "textField",
     }
 }

--- a/src/logic/questionGenerator.js
+++ b/src/logic/questionGenerator.js
@@ -1,6 +1,5 @@
 import { randomInt, chooseRandomFromArray } from "./lowLevelHelpers";
 
-
 export function blankQuestion() {
     return {
         type: "missingSumThree",
@@ -10,41 +9,7 @@ export function blankQuestion() {
         equationString: `0 + 0 + 0 = __`,
         inputType: "textField",
     }
-
 }
-
-
-
-export function generateQuestion(mathTopics, score) {
-    // 1) pick topic from array of options
-    const topic = chooseRandomFromArray(mathTopics)
-
-    // 2) determine difficulty based on score
-    const difficulty = determineDifficulty(score)
-    
-    let question
-    if (topic === "combining") {
-        question = getCombiningQuestion(difficulty)
-    }
-    else if (topic === "multiplying") {
-        question = getMultiplyingQuestion(difficulty)
-    }
-    // else if (topic === "fractions") {
-    //     question = getFractionsQuestion(difficulty)
-    // }
-    // else if (topic === "exponents") {
-    //     question = getExponentsQuestion(difficulty)
-    // }
-    // else if (topic === "algebra") {
-    //     question = getAlgebraQuestion(difficulty)
-    // }
-    else {
-        console.error(`FAILED TO GET QUESTION!!! with topic "${mathTopics}" and ${score} questions Right So Far`)
-    }
-    console.log(`Generated an "${difficulty}" ${topic} Question --> ${JSON.stringify(question, null, 4)}`);
-    return question
-}
-
 function determineDifficulty(score) {
     console.log(`determineDifficulty called with ${score} `);
     if (score < 6) {
@@ -62,36 +27,105 @@ function determineDifficulty(score) {
     }
 }
 
+
+
+export function generateQuestion(mathTopics, score) {
+    // 1) pick topic from array of options
+    // 2) determine difficulty based on score
+    // 3) call topic specific question generator
+    const topic = chooseRandomFromArray(mathTopics)
+    const difficulty = determineDifficulty(score)
+    let question
+    if (topic === "combining") {
+        question = getCombiningQuestion(difficulty)
+    }
+    else if (topic === "multiplying") {
+        question = getMultiplyingQuestion(difficulty)
+    }
+    // else if (topic === "fractions") {
+    //     question = getFractionsQuestion(difficulty)
+    // }
+    // else if (topic === "exponents") {
+    //     question = getExponentsQuestion(difficulty)
+    // }
+    // else if (topic === "algebra") {
+    //     question = getAlgebraQuestion(difficulty)
+    // }
+    else {
+        console.error(`generateQuestion FAILED with topic "${mathTopics}" and ${score} questions Right So Far!`)
+    }
+    console.log(`Generated an "${difficulty}" ${topic} Question --> ${JSON.stringify(question, null, 4)}`);
+    return question
+}
+
+
+
 function getCombiningQuestion(difficulty) {
     let types = [
         "missingSumTwo",
-        "missingAddendTwo",
-        "missingSumThree",
-        "missingAddendThree",
     ]
-        // "combineAndCompare"   // a + b _ c - d
-        // "missingDifference",  // a - b = _
-        // "missingMinuend",     // a - _ = c
-        // "howFarApart",        // a and b
-    
     let type = chooseRandomFromArray(types)
-    console.log(`Get Combining question type: "${type}"`);
-    let vars = getCombiningFact(type, difficulty) 
-    let correctAnswer = getCorrectAnswer(type, vars)
-    let instructions = getInstructions(type)
-    let equationString = getEquationString(type, vars)
-    let inputType = getInputType(type, vars)
+    // "missingAddendTwo",
+    // "missingSumThree",
+    // "missingAddendThree",
+    // "combineAndCompare"   // a + b _ c - d
+    // "missingDifference",  // a - b = _
+    // "missingMinuend",     // a - _ = c
+    // "howFarApart",        // a and b
 
-    let question = {
-        type: type,
-        vars: vars,
-        correctAnswer: correctAnswer,
-        instructions: instructions,
-        equationString: equationString,
-        inputType: inputType,
+    const missingSumInstructions = [
+        "What's the Sum?",
+        "Find the Total"
+    ]
+    const missingAddendInstructions = [
+        "What's missing?",
+        "How many more?"
+    ]
+    const getEasyAddend = () => { return randomInt(1, 20) }
+    const getMediumAddend = () => { return randomInt(20, 99) }
+    const getHardAddend = () => { return randomInt(99, 999) }
+    
+    
+    let question
+    if (type === "missingSumTwo") {
+        question = missingSumTwo(difficulty)
+    }
+    else if (type === "missingAddendTwo") {
+        question = missingAddendTwo(difficulty)
     }
     return question
     
+    function getSumOfTwoFact(difficulty) {
+        let a = (difficulty === "hard") ? getHardAddend() : getMediumAddend()
+        let b = (difficulty === "easy") ? getEasyAddend() : getMediumAddend()
+        let c = a + b
+        // console.log(`Combining Vars of difficulty "${difficultyLevel}": ${[a, b, c]}`);
+        return [a, b, c]
+    }
+    
+    function missingSumTwo(difficulty) {
+        let vars = getSumOfTwoFact(difficulty)
+        return question = {
+            type: "missingSumTwo",
+            vars: vars,
+            correctAnswer: vars[2],
+            instructions: chooseRandomFromArray(missingSumInstructions),
+            equationString: `${vars[0]} + ${vars[1]} = __`,
+            inputType: "textField",
+        }
+    }
+
+    function missingAddendTwo(difficulty) {
+        let vars = getSumOfTwoFact(difficulty)
+        return question = {
+            type: "missingAddendTwo",
+            vars: vars,
+            correctAnswer: vars[1],
+            instructions: chooseRandomFromArray(missingAddendInstructions),
+            equationString: `${vars[0]} + __ = ${vars[2]}`,
+            inputType: "textField",
+        }
+    }
     
     
 }
@@ -104,14 +138,7 @@ function getCombiningFact(type, difficultyLevel) {
     const getHardAddend = () => { return randomInt(99, 999) }
     
     // A + B = C
-    if (["missingSumTwo", "missingAddendTwo"].includes(type)) {
-        let a = (difficultyLevel === "hard") ? getHardAddend() : getMediumAddend()
-        let b = (difficultyLevel === "easy") ? getEasyAddend() : getMediumAddend()
-        let c = a + b
-        console.log(`Combining Vars of difficulty "${difficultyLevel}": ${[a, b, c]}`);
-        return [a, b, c]
-    }
-    else if (["missingSumThree", "missingAddendThree"].includes(type)) {
+    if (["missingSumThree", "missingAddendThree"].includes(type)) {
         let a = (difficultyLevel === "hard") ? getHardAddend() : getEasyAddend()
         let b = (difficultyLevel === "easy") ? getEasyAddend() : getMediumAddend()
         let c = (difficultyLevel === "easy") ? getEasyAddend() : getMediumAddend()
@@ -140,7 +167,6 @@ function getAlgebraQuestion(difficultyLevel) {
 
 function getEquationString(type, vars) {
     let questionTypeToEquationStringMap = new Map([
-        ["missingSumTwo", `${vars[0]} + ${vars[1]} = __`],
         ["missingSumThree", `${vars[0]} + ${vars[1]} + ${vars[2]} = __`],
         ["missingAddendTwo", `${vars[0]} + __ = ${vars[2]}`],
         ["missingAddendThree", `${vars[0]} + __ + ${vars[2]} = ${vars[3]}`],
@@ -218,10 +244,6 @@ function getInstructions(type) {
         ["third", chooseRandomFromArray(["What's a third of", "Cut in three"])],
         ["quarter", chooseRandomFromArray(["Quarter it!", "Half half it!", "What's a fourth of"])],
 
-        ["missingSumTwo", chooseRandomFromArray(["What's the Sum?", "Find the Total."])],
-        ["missingSumThree", chooseRandomFromArray(["What's the Sum?", "Find the Total."])],
-        ["missingAddendTwo", chooseRandomFromArray(["What's missing?", "How many more?"])],
-        ["missingAddendThree", chooseRandomFromArray(["What's missing?", "How many more?"])],
         ["missingProductTwo", chooseRandomFromArray(["Find the Product.", "Multiply."])],
         ["missingFactorTwo", chooseRandomFromArray(["What's missing?", "How many groups?"])],
         ["completeMultiplication", chooseRandomFromArray(["Find that factor!", "How many copies?"])],

--- a/src/logic/questionGenerator.js
+++ b/src/logic/questionGenerator.js
@@ -31,32 +31,38 @@ function determineDifficulty(score) {
 
 
 export function generateQuestion(mathTopics, score) {
+    return new Promise((resolve, reject) => {
+        const topic = chooseRandomFromArray(mathTopics)
+        const difficulty = determineDifficulty(score)
+        let question
+        if (topic === "combining") {
+            question = getCombiningQuestion(difficulty)
+        }
+        else if (topic === "multiplying") {
+            question = getMultiplyingQuestion(difficulty)
+        }
+        // else if (topic === "fractions") {
+        //     question = getFractionsQuestion(difficulty)
+        // }
+        // else if (topic === "exponents") {
+        //     question = getExponentsQuestion(difficulty)
+        // }
+        // else if (topic === "algebra") {
+        //     question = getAlgebraQuestion(difficulty)
+        // }
+        else {
+            reject(`generateQuestion FAILED with topic "${mathTopics}" and score ${score}!`)
+            // console.error(`generateQuestion FAILED with topic "${mathTopics}" and score ${score}!`)
+        }
+        console.log(`Generated an "${difficulty}" ${topic} Question --> ${JSON.stringify(question, null, 4)}`);
+
+        resolve(question)
+    });
+    
     // 1) pick topic from array of options
     // 2) determine difficulty based on score
     // 3) call topic specific question generator
-    const topic = chooseRandomFromArray(mathTopics)
-    const difficulty = determineDifficulty(score)
-    let question
-    if (topic === "combining") {
-        question = getCombiningQuestion(difficulty)
-    }
-    else if (topic === "multiplying") {
-        question = getMultiplyingQuestion(difficulty)
-    }
-    // else if (topic === "fractions") {
-    //     question = getFractionsQuestion(difficulty)
-    // }
-    // else if (topic === "exponents") {
-    //     question = getExponentsQuestion(difficulty)
-    // }
-    // else if (topic === "algebra") {
-    //     question = getAlgebraQuestion(difficulty)
-    // }
-    else {
-        console.error(`generateQuestion FAILED with topic "${mathTopics}" and ${score} questions Right So Far!`)
-    }
-    console.log(`Generated an "${difficulty}" ${topic} Question --> ${JSON.stringify(question, null, 4)}`);
-    return question
+    
 }
 
 
@@ -64,13 +70,12 @@ export function generateQuestion(mathTopics, score) {
 function getCombiningQuestion(difficulty) {
     let types = [
         "missingSumTwo",
-        "missingAddendTwo",
-        "missingAddendTwo",
         "missingSumThree",
+        "missingAddendTwo",
+        "missingAddendThree",
 
     ]
     let type = chooseRandomFromArray(types)
-    // "missingAddendThree",
     // "combineAndCompare"   // a + b _ c - d
     // "missingDifference",  // a - b = _
     // "missingMinuend",     // a - _ = c

--- a/src/modals/MathQuestionModal.js
+++ b/src/modals/MathQuestionModal.js
@@ -26,39 +26,14 @@ export function MathQuestionModal(props) {
 
     // const initialQuestion = blankQuestion()
     const initialQuestion = generateQuestion(["combining"], 0)
-    const [question, setQuestion] = React.useState(initialQuestion)
+    // const [question, setQuestion] = React.useState(initialQuestion)
+    const [question, setQuestion] = React.useState(generateQuestion(mathTopics, score))
+
     
     let { correctAnswer, instructions, equationString } = question
 
-    const [playersAnswer, setPlayersAnswer] = React.useState("")
     const [headerText, setHeaderText] = React.useState(instructions)
-
-    const answerIsNum = /^\d+$/.test(playersAnswer)
-    const error = (playersAnswer.length > 0 && !answerIsNum)
     
-    function answerIsCorrect(pa = playersAnswer, ca = correctAnswer) {
-        return (Number(pa.trim()) === ca)
-    }
-    const handlePlayersAnswerChange = (event) => {
-        let updatedAnswer = event.target.value.trim()
-        setPlayersAnswer(updatedAnswer)
-    }
-    function handleSubmitButtonClick() {
-        if (error) {
-            console.warn(`Returning early from answer submit b/c answer is blank or not a number.`);
-            return -1
-        }
-        const correct = answerIsCorrect()
-        const answerFeedbackHeaderText = (correct ? "Correct!" : `Nope. It was ${correctAnswer}.`)
-        setHeaderText(answerFeedbackHeaderText)
-        handleAnswerSubmit(correct)
-        setTimeout(() => {
-            setPlayersAnswer("")
-            setHeaderText(instructions)
-            // setQuestion(generateQuestion(mathTopics, score))
-        }, 1500);
-
-    }
 
     return (
         <Dialog 
@@ -92,9 +67,6 @@ export function MathQuestionModal(props) {
             />
             <AnswerInputComponent 
                 question={question}
-                error={error}
-                handlePlayersAnswerChange={handlePlayersAnswerChange}
-                handleSubmitButtonClick={handleSubmitButtonClick}
             />
         </Dialog>
     )
@@ -138,8 +110,36 @@ export function MathQuestionModal(props) {
         )
     }
     function AnswerInputComponent(props) {
-        const { question, error, handleSubmitButtonClick, handlePlayersAnswerChange } = props
+        const { question } = props
         const answerInputType = question.inputType
+
+        const [playersAnswer, setPlayersAnswer] = React.useState("")
+        const answerIsNum = /^\d+$/.test(playersAnswer)
+        const error = (playersAnswer.length > 0 && !answerIsNum)
+
+        function answerIsCorrect(pa = playersAnswer, ca = correctAnswer) {
+            return (Number(pa.trim()) === ca)
+        }
+        const handlePlayersAnswerChange = (event) => {
+            let updatedAnswer = event.target.value.trim()
+            setPlayersAnswer(updatedAnswer)
+        }
+        function handleSubmitButtonClick() {
+            if (error) {
+                console.warn(`Returning early from answer submit b/c answer is blank or not a number.`);
+                return -1
+            }
+            const correct = answerIsCorrect()
+            const answerFeedbackHeaderText = (correct ? "Correct!" : `Nope. It was ${correctAnswer}.`)
+            setHeaderText(answerFeedbackHeaderText)
+            handleAnswerSubmit(correct)
+            setTimeout(() => {
+                setPlayersAnswer("")
+                setHeaderText(instructions)
+                // setQuestion(generateQuestion(mathTopics, score))
+            }, 1500);
+
+        }
 
         if (answerInputType === "textField") {
             return (
@@ -163,7 +163,6 @@ export function MathQuestionModal(props) {
 
         function NumericalTextInput(props) {
             const { error, handleSubmitButtonClick } = props
-            
 
             return (
                 <Box sx={{

--- a/src/modals/MathQuestionModal.js
+++ b/src/modals/MathQuestionModal.js
@@ -19,10 +19,15 @@ const Transition = React.forwardRef(function Transition(props, ref) {
 
 
 export function MathQuestionModal(props) {
-    let { question, open, handleAnswerSubmit, boardSideLength } = props  // turnNumber,
+    let { question, 
+        open, 
+        handleAnswerSubmit, 
+        boardSideLength,
+        turnNumber,
+        headerText } = props 
+    
     let { correctAnswer, instructions, equationString, inputType } = question
 
-    const [headerText, setHeaderText] = useState(instructions)
 
     return (
         <Dialog 
@@ -102,31 +107,22 @@ export function MathQuestionModal(props) {
         )
     }
     function AnswerInputComponent(props) {
-        // const { question } = props
-        // const { inputType, correctAnswer }  = question
         const { inputType, correctAnswer, handleAnswerSubmit } = props
-
 
         const [playersAnswer, setPlayersAnswer] = React.useState("")
         const answerIsNum = /^\d+$/.test(playersAnswer)
         const error = (playersAnswer.length > 0 && !answerIsNum)
 
-        function answerIsCorrect(pa = playersAnswer, ca = correctAnswer) {
-            return (Number(pa.trim()) === ca)
-        }
+        // function answerIsCorrect(pa = playersAnswer, ca = correctAnswer) {
+        //     return (Number(pa.trim()) === ca)
+        // }
         const handlePlayersAnswerChange = (event) => {
             let updatedAnswer = event.target.value.trim()
             setPlayersAnswer(updatedAnswer)
         }
         function handleSubmitButtonClick() {
-            if (error) {
-                console.warn(`Returning early from answer submit b/c answer is blank or not a number.`);
-                return -1
-            }
-            const correct = answerIsCorrect()
-            const answerFeedbackHeaderText = (correct ? "Correct!" : `Nope. It was ${correctAnswer}.`)
-            setHeaderText(answerFeedbackHeaderText)
-            handleAnswerSubmit(correct)
+            
+            handleAnswerSubmit(playersAnswer)
             // setTimeout(() => {
             //     setPlayersAnswer("")
             //     setHeaderText(instructions)

--- a/src/modals/MathQuestionModal.js
+++ b/src/modals/MathQuestionModal.js
@@ -5,7 +5,7 @@ import React, { useState } from 'react'
 import { Box, Button, Dialog, Zoom, Typography, 
     TextField, FormControl, InputLabel, OutlinedInput, FormHelperText,  
 } from '@material-ui/core'
-import { generateQuestion, blankQuestion } from '../logic/questionGenerator'
+import { generateQuestion, testQuestion } from '../logic/questionGenerator'
 
 // Style & Layout Constants
 const instructionsHeight = "30%"
@@ -19,25 +19,14 @@ const Transition = React.forwardRef(function Transition(props, ref) {
 
 
 export function MathQuestionModal(props) {
-    let { mathTopics, score, turnNumber, open, handleAnswerSubmit, boardSideLength } = props
-    
-    mathTopics = (mathTopics === undefined) ? ["combining"] : mathTopics
-    score = (score === undefined) ? 0 : score
+    let { question, open, handleAnswerSubmit, boardSideLength } = props  // turnNumber,
+    let { correctAnswer, instructions, equationString, inputType } = question
 
-    // const initialQuestion = blankQuestion()
-    const initialQuestion = generateQuestion(["combining"], 0)
-    // const [question, setQuestion] = React.useState(initialQuestion)
-    const [question, setQuestion] = React.useState(generateQuestion(mathTopics, score))
-
-    
-    let { correctAnswer, instructions, equationString } = question
-
-    const [headerText, setHeaderText] = React.useState(instructions)
-    
+    const [headerText, setHeaderText] = useState(instructions)
 
     return (
         <Dialog 
-            keepMounted
+            // keepMounted
             disableEscapeKeyDown
             open={open}
             onBackdropClick={() => {}}  // disable close on bg click
@@ -59,7 +48,7 @@ export function MathQuestionModal(props) {
         >
             <HeaderText 
                 // key={1}
-                key={turnNumber}  // May be able to use key prop to force state reset to initial.
+                // key={turnNumber}  // May be able to use key prop to force state reset to initial.
                 headerText={headerText}
             />
             <QuestionEquation 

--- a/src/modals/MathQuestionModal.js
+++ b/src/modals/MathQuestionModal.js
@@ -25,8 +25,8 @@ export function MathQuestionModal(props) {
     score = (score === undefined) ? 0 : score
 
     // const [question, setQuestion] = React.useState(blankQuestion())
-    const [question, setQuestion] = React.useState(generateQuestion(mathTopics, score))
-
+    const initialQuestion = generateQuestion(["combining"], 0)
+    const [question, setQuestion] = React.useState(initialQuestion)
     
     let { correctAnswer, instructions, equationString } = question
 

--- a/src/modals/MathQuestionModal.js
+++ b/src/modals/MathQuestionModal.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
-
+// Logic
+import { gameIsOver, nextPlayerColor } from '../logic/connectFourLogic'
 
 // MUI  components
 import { Box, Button, Dialog, Zoom, Typography, 
@@ -21,6 +22,8 @@ const Transition = React.forwardRef(function Transition(props, ref) {
 export function MathQuestionModal(props) {
     let { question, 
         open, 
+        gameStatus,
+        nextPlayerColor,
         handleAnswerSubmit, 
         boardSideLength,
         turnNumber,
@@ -28,6 +31,7 @@ export function MathQuestionModal(props) {
     
     let { correctAnswer, instructions, equationString, inputType } = question
 
+    let borderColor = `chip.${nextPlayerColor}`
 
     return (
         <Dialog 
@@ -40,7 +44,11 @@ export function MathQuestionModal(props) {
             fullWidth={true}
             maxWidth='md'
             PaperProps={{
-                style: {
+                sx: {
+                    // border: `solid ${nextPlayerColor(gameStatus)} 5px`,
+                    border: `solid green 0.5rem`,
+                    // border: `solid ${borderColor} 5px`,
+                    borderColor: borderColor,
                     margin: `${0.05 * boardSideLength}px`,
                     height: `${0.9 * boardSideLength}px`,
                     width: `${0.9 * boardSideLength}px`,
@@ -113,28 +121,19 @@ export function MathQuestionModal(props) {
         const answerIsNum = /^\d+$/.test(playersAnswer)
         const error = (playersAnswer.length > 0 && !answerIsNum)
 
-        // function answerIsCorrect(pa = playersAnswer, ca = correctAnswer) {
-        //     return (Number(pa.trim()) === ca)
-        // }
         const handlePlayersAnswerChange = (event) => {
             let updatedAnswer = event.target.value.trim()
             setPlayersAnswer(updatedAnswer)
         }
         function handleSubmitButtonClick() {
             
-            handleAnswerSubmit(playersAnswer)
-            // setTimeout(() => {
-            //     setPlayersAnswer("")
-            //     setHeaderText(instructions)
-            //     // setQuestion(generateQuestion(mathTopics, score))
-            // }, 1500);
         }
 
         if (inputType === "textField") {
             return (
                 <NumericalTextInput
                     error={error}
-                    handleSubmitButtonClick={handleSubmitButtonClick}
+                    handleSubmitButtonClick={() => handleAnswerSubmit(playersAnswer)}
                 />
             )
         }

--- a/src/modals/MathQuestionModal.js
+++ b/src/modals/MathQuestionModal.js
@@ -55,7 +55,10 @@ export function MathQuestionModal(props) {
                 equationString={equationString}
             />
             <AnswerInputComponent 
-                question={question}
+                inputType={inputType}
+                correctAnswer={correctAnswer}
+                handleAnswerSubmit={handleAnswerSubmit}
+                // question={question}
             />
         </Dialog>
     )
@@ -99,8 +102,10 @@ export function MathQuestionModal(props) {
         )
     }
     function AnswerInputComponent(props) {
-        const { question } = props
-        const answerInputType = question.inputType
+        // const { question } = props
+        // const { inputType, correctAnswer }  = question
+        const { inputType, correctAnswer, handleAnswerSubmit } = props
+
 
         const [playersAnswer, setPlayersAnswer] = React.useState("")
         const answerIsNum = /^\d+$/.test(playersAnswer)
@@ -122,15 +127,14 @@ export function MathQuestionModal(props) {
             const answerFeedbackHeaderText = (correct ? "Correct!" : `Nope. It was ${correctAnswer}.`)
             setHeaderText(answerFeedbackHeaderText)
             handleAnswerSubmit(correct)
-            setTimeout(() => {
-                setPlayersAnswer("")
-                setHeaderText(instructions)
-                // setQuestion(generateQuestion(mathTopics, score))
-            }, 1500);
-
+            // setTimeout(() => {
+            //     setPlayersAnswer("")
+            //     setHeaderText(instructions)
+            //     // setQuestion(generateQuestion(mathTopics, score))
+            // }, 1500);
         }
 
-        if (answerInputType === "textField") {
+        if (inputType === "textField") {
             return (
                 <NumericalTextInput
                     error={error}
@@ -138,7 +142,7 @@ export function MathQuestionModal(props) {
                 />
             )
         }
-        else if (answerInputType === "compareButtons") {
+        else if (inputType === "compareButtons") {
             return (
                 <CompareButtons 
                     // handleAnswerSubmit={handleAnswerSubmit}
@@ -147,7 +151,7 @@ export function MathQuestionModal(props) {
             )
         }
         else {
-            console.error(`getInputComponent failed. Invalid answerInputType: ${answerInputType}`)
+            console.error(`getInputComponent failed. Invalid inputType: ${inputType}`)
         }
 
         function NumericalTextInput(props) {

--- a/src/modals/MathQuestionModal.js
+++ b/src/modals/MathQuestionModal.js
@@ -24,7 +24,7 @@ export function MathQuestionModal(props) {
     mathTopics = (mathTopics === undefined) ? ["combining"] : mathTopics
     score = (score === undefined) ? 0 : score
 
-    // const [question, setQuestion] = React.useState(blankQuestion())
+    // const initialQuestion = blankQuestion()
     const initialQuestion = generateQuestion(["combining"], 0)
     const [question, setQuestion] = React.useState(initialQuestion)
     
@@ -55,7 +55,7 @@ export function MathQuestionModal(props) {
         setTimeout(() => {
             setPlayersAnswer("")
             setHeaderText(instructions)
-            setQuestion(generateQuestion(mathTopics, score))
+            // setQuestion(generateQuestion(mathTopics, score))
         }, 1500);
 
     }

--- a/src/pages/GameBoard.js
+++ b/src/pages/GameBoard.js
@@ -265,7 +265,6 @@ function ChipContainer(props) {
     return (
         <Box id="chipContainer"
             sx={{
-                bgcolor: 'primary.main',
                 width: '100%',
                 height: '100%',
                 position: 'absolute',


### PR DESCRIPTION
**Redesigned the question generator** 
to return a promise so that actions in the open modal function of App.js can be delayed until the generator has completed its work.  
**Reorganized State:**
1. moved playersAnswer pre-submit click Down into the Answer Input Component so that frequent updates made to it will not trigger re-renders of the entire question modal.  
2. moved question Up into the App layer. This put a stop to the generating of many questions that never got used during each re-render of the question modal.  For example, when headerText would update a question would be generated and never used.
3. moved headerText up to the App layer so that it can be updated both when the modal opens and when submit is clicked. Previously it was located in the Input component where handleSubmitClick is defined and was causing async effect errors when the  handleSubmitClick function would try to reset it to point to the instructions with a delay that made this occur after the modal had unmounted.

Also added colored border to question Modal to remind players whose turn it is while the modal is open.